### PR TITLE
Unified version name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def build_id = System.getenv("GITHUB_RUN_NUMBER");
 if (build_id == null) {
     version = "${project.mod_version}-SNAPSHOT"
 } else {
-    version = "${project.mod_version}+build.${build_id}"
+    version = "${project.mod_version}"
 }
 
 minecraft {


### PR DESCRIPTION
Taking a look at Phosphor and Lithium's latest release page, they has the following asset file names:

<table>
<tr>
	<td> <a href="https://github.com/CaffeineMC/phosphor-fabric/releases/tag/mc1.16.2-v0.7.2">Phosphor</a>
	<td> <code>phosphor-fabric-mc1.16.3-0.7.2+build.12.jar</code>
<tr>
	<td> <a href="https://github.com/CaffeineMC/lithium-fabric/releases/tag/mc1.17.1-0.7.4">Lithium</a>
	<td> <code>lithium-fabric-mc1.17.1-0.7.4.jar</code>
</table>

Each asset file has a download link: `https://github.com/CaffeineMC/{repo}/releases/download/{tag}/{file_name}`.

Here is a table summarising how Phosphor and Lithium name their asset files after each release (examples based on the above table):
<table>
<tr>
	<td>
	<td> Minecraft version
	<td> Build version
	<td> Build ID
	<td> Type
<tr>
	<td> Phosphor
		<br/>
		E.g. with tag <code>mc1.16.2-v0.7.2</code>
	<td>
		<code>mc{minecraft_version}</code>
		<br/>
		E.g. <code>mc1.16.3</code>
	<td>
		<code>{build_version}</code>
		<br/>
		E.g. <code>0.7.2</code>
	<td>
		<code>+build.{build_id}</code>
		<br/>
		E.g. <code>+build.12</code>
	<td>
		<code>{build_type}</code>
		<br/>
		E.g. null or <code>-sources</code>, <code>-dev</code>, <code>-sources-dev</code>
<tr>
	<td> Lithium
		<br/>
		E.g. with tag <code>mc1.17.1-0.7.4</code>
	<td>
		<code>mc{minecraft_version}</code>
		<br/>
		E.g. <code>mc1.17.1</code>
	<td>
		<code>{build_version}</code>
		<br/>
		E.g. <code>0.7.4</code>
	<td> x
	<td>
		<code>{build_type}</code>
		<br/>
		E.g. null or <code>-api</code>
</table>

As you can see, Lithium's asset file name (mc1.17.1-0.7.4) equals its release's tag, while Phosphor's (mc1.16.3-0.7.2+build.12) is completely different from its tag (mc1.16.2-0.7.2). This is very confusing, as this [title][phosphor-0.7.2] says `Phosphor 0.7.2 for Minecraft 1.16.2+`, but one downloaded `mc1.16.3`, so one can wonders if it is compatible with MC 1.16.2 or not?

I suppose we can get rid of `+build.{build_id}`, as providing build version would be enough if testers are to report issues on newly untested CI builds.

All in all, I propose a new way of naming asset files: `phosphor-fabric-{tag}{build_type}.jar`, with `{tag}` equals each release's tag.

That way, automation tools can determine Phosphor's latest stable tag and download the appropriate file for end users without second-guessing its file name.

- [x] Remove build id
- [ ] Find out where Phosphor rename asset file, so it can match its own tag.

[phosphor-0.7.2]: https://github.com/CaffeineMC/phosphor-fabric/releases/tag/mc1.16.2-v0.7.2